### PR TITLE
Correct Rotation based on MRA expectation

### DIFF
--- a/releases/Alcon Bootleg.mra
+++ b/releases/Alcon Bootleg.mra
@@ -8,7 +8,7 @@
 	<manufacturer>Toaplan</manufacturer>
 	<category>Shooter</category>
 	<rbf>SlapFight</rbf>
-	<rotation>vertical (ccw)</rotation>
+	<rotation>vertical (cw)</rotation>
 	<joystick>8-way</joystick>
 	<switches default="FF,FF,FF">
 		<dip bits="15" name="Cabinet Type" ids="Table,Up-Right"/>

--- a/releases/SlapFight Bootleg.mra
+++ b/releases/SlapFight Bootleg.mra
@@ -8,7 +8,7 @@
 	<manufacturer>Toaplan</manufacturer>
 	<category>Shooter</category>
 	<rbf>SlapFight</rbf>
-	<rotation>vertical (ccw)</rotation>
+	<rotation>vertical (cw)</rotation>
 	<joystick>8-way</joystick>
 	<switches default="FF,FF,FF">
 		<dip bits="15" name="Cabinet Type" ids="Table,Up-Right"/>

--- a/releases/Tiger Heli Bootleg.mra
+++ b/releases/Tiger Heli Bootleg.mra
@@ -8,7 +8,7 @@
 	<manufacturer>Toaplan</manufacturer>
 	<category>Shooter</category>
 	<rbf>SlapFight</rbf>
-	<rotation>vertical (ccw)</rotation>
+	<rotation>vertical (cw)</rotation>
 	<joystick>8-way</joystick>
 	<switches default="FF,FF,FF">
 		<dip bits="15" name="Heli Speed" ids="Fast,Normal"/>


### PR DESCRIPTION
The rotation flag in MRAs is based around the direction the mister has to rotate it, rather than the direction the video is rotated. This value used to not matter, but now the MiSTer sends the rotation information in the DV infoframe so that scalers can automatically rotate the image.